### PR TITLE
fix compile errors by using `const`.

### DIFF
--- a/08map_buffer.cpp
+++ b/08map_buffer.cpp
@@ -198,7 +198,7 @@ int main() {
     }
 
     
-    int buffercount = 3;
+    const int buffercount = 3;
     // generate vbos and vaos
     GLuint vao[buffercount], vbo[buffercount];
     glGenVertexArrays(buffercount, vao);

--- a/09transform_feedback.cpp
+++ b/09transform_feedback.cpp
@@ -278,7 +278,7 @@ int main() {
         vertexData[2*i+1] = glm::vec3(0,0,0);
     }
     
-    int buffercount = 2;
+    const int buffercount = 2;
     // generate vbos and vaos
     GLuint vao[buffercount], vbo[buffercount];
     glGenVertexArrays(buffercount, vao);


### PR DESCRIPTION
compilers hate us.